### PR TITLE
Update fixclosure 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,20 +24,20 @@
     }
   ],
   "devDependencies": {
-    "cpr": "~0.1.1",
+    "cpr": "~0.2.0",
     "expect.js": "~0.3.1",
     "grunt-cli": "~0.1.13",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-mocha-test": "~0.10.2",
-    "load-grunt-tasks": "~0.4.0",
-    "mocha": "~1.18.2"
+    "grunt-mocha-test": "~0.11.0",
+    "load-grunt-tasks": "~0.5.0",
+    "mocha": "~1.20.1"
   },
   "scripts": {
     "test": "node_modules/grunt-cli/bin/grunt"
   },
   "dependencies": {
-    "fixclosure": "~1.2.0"
+    "fixclosure": "^1.3.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"


### PR DESCRIPTION
and use caret operator `^1.3.0` instead of tilde `~1.2.0`.
